### PR TITLE
Modificación para compatibilidad con CheckoutWC

### DIFF
--- a/template/checkout/jetiframe-checkout.php
+++ b/template/checkout/jetiframe-checkout.php
@@ -141,7 +141,7 @@ function jetIframeValidated(){
 
 // formSubmit
 jQuery( function( $ ) {
-    $( "#place_order").on('click',function( event ) {
+    $(document).on('click','#place_order',function( event ) {
         if ($( '#payment_method_paytpv' ).is( ':checked' )) {
             event.preventDefault();
 


### PR DESCRIPTION
El plugins se insertaba perfectamente en el CheckoutWC, pero cuando se hacia click en el botón de Finalizar Compra (#place_order), si dejaba los campos de la tarjeta vacíos o si insertabas los datos, no entraba en funcionamiento el evento de paycomet. Realice este cambio y nos funciona perfectamente. 
He comprobado este cambio y funciona tanto con CheckoutWC como si desactivamos este y utilizados el carrito del theme.